### PR TITLE
Make "Quick Start" quicker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ run
 # Files from Forge MDK
 forge*changelog.txt
 
+.cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,3 +7,15 @@ SHELL ["/bin/bash", "-c"]
 
 WORKDIR /ws/minecraft_ros2
 COPY . .
+
+RUN <<EOF
+    apt-get update
+    apt-get install -y ros-humble-rviz2
+    apt-get clean
+    rm -rf /var/lib/apt/lists
+EOF
+
+COPY --chmod=755 <<EOF runRviz.sh
+    source /opt/ros/humble/setup.bash
+    rviz2 -d ./minecraft.rviz
+EOF

--- a/README.md
+++ b/README.md
@@ -33,34 +33,22 @@ Docker provides a convenient way to try out the environment in this repository. 
    xhost +local:root
    ```
 
-2. **Make shared directory**
-
-   Run this step only once during the initial setup.
-   ```bash
-   docker volume create minecraft_ros2_gradle_cache
-   mkdir -p ~/.minecraft
-   ```
-
-3. **Start the Docker Container**
+2. **Clone this repository**
 
    ```bash
-   docker run -it --rm \
-     --env="DISPLAY=$DISPLAY" \
-     --env="QT_X11_NO_MITSHM=1" \
-     --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" \
-     --mount source=minecraft_ros2_gradle_cache,target=/root/.gradle \
-     -v ~/.minecraft:/ws/minecraft_ros2/run \
-     ghcr.io/minecraft-ros2/minecraft_ros2:latest \
-     /bin/bash ./runClient.sh
+   git clone https://github.com/minecraft-ros2/minecraft_ros2.git
+   cd minecraft_ros2
    ```
 
-   * If you want to use the GPU, add `--gpus all` (requires NVIDIA Container Toolkit):
+3. **Start Docker Containers**
 
-4. **Verify Operation with Tools like `rviz2`**
-   
-   Once ROS 2 is running inside the container, you can start tools like `rviz2` from another terminal to visualize the data.
+   ```bash
+   docker compose up
+   ```
 
-5. **Restore permissions**
+   Running this command will start both Minecraft and RViz. To learn how to visualize point clouds in RViz, check out the [How to Use the Sensor](#how-to-use-the-sensor) section.
+
+4. **Restore permissions**
    ```bash
    xhost -local:root
    ```

--- a/README_JP.md
+++ b/README_JP.md
@@ -30,35 +30,22 @@
    ```bash
    xhost +local:root
    ```
-2. **共有ディレクトリの作成**
+2. **リポジトリのクローン**
 
-   この手順は初回セットアップ時に一度だけ実行してください。
    ```bash
-   docker volume create minecraft_ros2_gradle_cache
-   mkdir -p ~/.minecraft
+   git clone https://github.com/minecraft-ros2/minecraft_ros2.git
+   cd minecraft_ros2
    ```
 
 3. **Docker コンテナを起動**
 
    ```bash
-   docker run -it --rm \
-     --env="DISPLAY=$DISPLAY" \
-     --env="QT_X11_NO_MITSHM=1" \
-     --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" \
-     --mount source=minecraft_ros2_gradle_cache,target=/root/.gradle \
-     -v ~/.minecraft:/ws/minecraft_ros2/run \
-     ghcr.io/minecraft-ros2/minecraft_ros2:latest \
-     /bin/bash ./runClient.sh
+   docker compose up
    ```
 
-   * GPU を使いたい場合は `--gpus all` を追加してください（NVIDIA Container Toolkit のインストールが必要です）:
+   このコマンドを実行すると、MinecraftとRVizが同時に起動します。RVizで点群を表示する方法については、[センサーの使い方](#センサーの使い方)をご覧ください。
 
-
-4. **`rviz2` などで動作を確認**
-
-   コンテナ内で ROS 2 が立ち上がった後、別端末で `rviz2` を起動することで可視化が可能です：
-
-5. 権限の復元
+4. 権限の復元
    ```bash
    xhost -local:root
    ```

--- a/compose.yaml
+++ b/compose.yaml
@@ -19,8 +19,6 @@ services:
               count: all
 
   rviz:
-    depends_on:
-      - minecraft
     image: minecraft-ros2/minecraft-ros2-local-build
     pull_policy: never
     command: ./runRviz.sh

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,37 @@
+services:
+  minecraft:
+    build: .
+    image: minecraft-ros2/minecraft-ros2-local-build
+    pull_policy: never
+    command: ./runClient.sh
+    environment:
+      - DISPLAY=${DISPLAY}
+      - QT_X11_NO_MITSHM=1
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix
+      - ./.cache/minecraft:/ws/minecraft_ros2/run
+      - ./.cache/gradle:/root/.gradle
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: [gpu]
+              count: all
+
+  rviz:
+    depends_on:
+      - minecraft
+    image: minecraft-ros2/minecraft-ros2-local-build
+    pull_policy: never
+    command: ./runRviz.sh
+    environment:
+      - DISPLAY=${DISPLAY}
+      - QT_X11_NO_MITSHM=1
+    volumes:
+      - /tmp/.X11-unix:/tmp/.X11-unix
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: [gpu]
+              count: all


### PR DESCRIPTION
This pull request aims to make the "Quick Start" experience much smoother and faster.

Previously, users had to:
* Copy and paste very long Docker commands.
* Start RViz in a separate terminal after Docker was running.

Now, with this PR, everything is simplified. You can just use `docker compose up` to:
* **Start everything you need, including RViz.**
* **Avoid typing or copying long commands.**

This means less hassle and a quicker way to get up and running!

---

**Important Testing Request:**

I primarily developed and verified these changes within a **WSL** environment. To ensure broad compatibility, it would be extremely helpful if someone could test this pull request specifically on a **native Linux desktop setup** (not WSL). Please let me know if you encounter any issues. Thanks!