### PR TITLE
Fix link of batch in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Minecraft\_ros2
 [![build mod](https://github.com/minecraft-ros2/minecraft_ros2/actions/workflows/build_test.yaml/badge.svg)](https://github.com/minecraft-ros2/minecraft_ros2/actions/workflows/build_test.yaml)
-[![build docker image](https://github.com/minecraft-ros2/minecraft_ros2/actions/workflows/docker_build.yaml/badge.svg)](https://github.com/minecraft-ros2/minecraft_ros2/actions/workflows/docker_build.yaml)
+[![build docker image](https://github.com/minecraft-ros2/minecraft_ros2/actions/workflows/docker_build_main.yaml/badge.svg)](https://github.com/minecraft-ros2/minecraft_ros2/actions/workflows/docker_build_main.yaml)
 
 [日本語](README_JP.md)
 

--- a/README_JP.md
+++ b/README_JP.md
@@ -1,6 +1,6 @@
 # Minecraft\_ros2（日本語版）
 [![build mod](https://github.com/minecraft-ros2/minecraft_ros2/actions/workflows/build_test.yaml/badge.svg)](https://github.com/minecraft-ros2/minecraft_ros2/actions/workflows/build_test.yaml)
-[![build docker image](https://github.com/minecraft-ros2/minecraft_ros2/actions/workflows/docker_build.yaml/badge.svg)](https://github.com/minecraft-ros2/minecraft_ros2/actions/workflows/docker_build.yaml)
+[![build docker image](https://github.com/minecraft-ros2/minecraft_ros2/actions/workflows/docker_build_main.yaml/badge.svg)](https://github.com/minecraft-ros2/minecraft_ros2/actions/workflows/docker_build_main.yaml)
 
 **minecraft_ros2** は、Minecraft と ROS 2 を統合する MOD です。Minecraft のワールドデータ（例：プレイヤーの位置やブロックの状態など）を ROS 2 にパブリッシュすることができ、RViz2 上での可視化や ROS 2 ノードとの連携が可能になります。
 


### PR DESCRIPTION
https://github.com/minecraft-ros2/minecraft_ros2/pull/37 で取り残されたと思われるREADME内のリンクの更新です